### PR TITLE
Move entire folder content

### DIFF
--- a/lib/fastlane/plugin/rename_android_package/actions/rename_android_package_action.rb
+++ b/lib/fastlane/plugin/rename_android_package/actions/rename_android_package_action.rb
@@ -9,18 +9,22 @@ module Fastlane
         package_name = params[:package_name]
         new_package_name = params[:new_package_name]
 
-        folder = package_name.gsub('.', '/')
-        new_folder = new_package_name.gsub('.', '/')
-        new_folder_path = "#{path}/app/src/main/java/#{new_folder}"
+        if package_name != new_package_name
+        
+          folder = package_name.gsub('.', '/')
+          new_folder = new_package_name.gsub('.', '/')
+          new_folder_path = "#{path}/app/src/main/java/#{new_folder}"
 
-        FileUtils.mkdir_p(new_folder_path)
-        FileUtils.mv Dir.glob("#{path}/app/src/main/java/#{folder}/*"), new_folder_path
+          FileUtils.mkdir_p(new_folder_path)
+          FileUtils.mv Dir.glob("#{path}/app/src/main/java/#{folder}/*"), new_folder_path
 
-        Bundler.with_unbundled_env do
-          sh "find #{path}/app/src -name '*.java' -type f -exec sed -i '' 's/#{package_name}/#{new_package_name}/' {} \\;"
-          sh "find #{path}/app/src -name 'AndroidManifest.xml' -type f -exec sed -i '' 's/#{package_name}/#{new_package_name}/' {} \\;"
-          sh "find #{path}/app -name 'build.gradle' -type f -exec sed -i '' 's/#{package_name}/#{new_package_name}/' {} \\;"
+          Bundler.with_unbundled_env do
+            sh "find #{path}/app/src -name '*.java' -type f -exec sed -i '' 's/#{package_name}/#{new_package_name}/' {} \\;"
+            sh "find #{path}/app/src -name 'AndroidManifest.xml' -type f -exec sed -i '' 's/#{package_name}/#{new_package_name}/' {} \\;"
+            sh "find #{path}/app -name 'build.gradle' -type f -exec sed -i '' 's/#{package_name}/#{new_package_name}/' {} \\;"
+          end
         end
+       UI.message "Old and new package names match, nothing to do, exiting"
       end
 
       def self.description

--- a/lib/fastlane/plugin/rename_android_package/actions/rename_android_package_action.rb
+++ b/lib/fastlane/plugin/rename_android_package/actions/rename_android_package_action.rb
@@ -13,7 +13,8 @@ module Fastlane
         new_folder = new_package_name.gsub('.', '/')
         new_folder_path = "#{path}/app/src/main/java/#{new_folder}"
 
-        FileUtils.mv "#{path}/app/src/main/java/#{old_folder}/*", new_folder_path
+        FileUtils.mkdir_p(new_folder_path)
+        FileUtils.mv Dir.glob("#{path}/app/src/main/java/#{folder}/*"), new_folder_path
 
         Bundler.with_unbundled_env do
           sh "find #{path}/app/src -name '*.java' -type f -exec sed -i '' 's/#{package_name}/#{new_package_name}/' {} \\;"

--- a/lib/fastlane/plugin/rename_android_package/actions/rename_android_package_action.rb
+++ b/lib/fastlane/plugin/rename_android_package/actions/rename_android_package_action.rb
@@ -23,8 +23,9 @@ module Fastlane
             sh "find #{path}/app/src -name 'AndroidManifest.xml' -type f -exec sed -i '' 's/#{package_name}/#{new_package_name}/' {} \\;"
             sh "find #{path}/app -name 'build.gradle' -type f -exec sed -i '' 's/#{package_name}/#{new_package_name}/' {} \\;"
           end
+        else
+          UI.message "Old and new package names match, nothing to do, exiting"
         end
-       UI.message "Old and new package names match, nothing to do, exiting"
       end
 
       def self.description

--- a/lib/fastlane/plugin/rename_android_package/actions/rename_android_package_action.rb
+++ b/lib/fastlane/plugin/rename_android_package/actions/rename_android_package_action.rb
@@ -13,12 +13,7 @@ module Fastlane
         new_folder = new_package_name.gsub('.', '/')
         new_folder_path = "#{path}/app/src/main/java/#{new_folder}"
 
-        FileUtils::mkdir_p new_folder_path
-
-        java_sources = Dir.glob("#{path}/app/src/main/java/#{folder}/*.java")
-        java_sources.each do |file|
-          FileUtils.mv file, new_folder_path
-        end
+        FileUtils.mv "#{path}/app/src/main/java/#{old_folder}/*", new_folder_path
 
         Bundler.with_clean_env do
           sh "find #{path}/app/src -name '*.java' -type f -exec sed -i '' 's/#{package_name}/#{new_package_name}/' {} \\;"

--- a/lib/fastlane/plugin/rename_android_package/actions/rename_android_package_action.rb
+++ b/lib/fastlane/plugin/rename_android_package/actions/rename_android_package_action.rb
@@ -15,7 +15,7 @@ module Fastlane
 
         FileUtils.mv "#{path}/app/src/main/java/#{old_folder}/*", new_folder_path
 
-        Bundler.with_clean_env do
+        Bundler.with_unbundled_env do
           sh "find #{path}/app/src -name '*.java' -type f -exec sed -i '' 's/#{package_name}/#{new_package_name}/' {} \\;"
           sh "find #{path}/app/src -name 'AndroidManifest.xml' -type f -exec sed -i '' 's/#{package_name}/#{new_package_name}/' {} \\;"
           sh "find #{path}/app -name 'build.gradle' -type f -exec sed -i '' 's/#{package_name}/#{new_package_name}/' {} \\;"


### PR DESCRIPTION
Hi!

The react native new architecture introduces some new folders in the package folder, namely the newarchitecture folder, which contains yet a couple more folders. This aims to fix #2

I'm not a native android dev, but a React Native one. Would moving the entire package folder contents at once cause issues with other project setups?

