### PR TITLE
feature: making 'sed' command OS depended

### DIFF
--- a/lib/fastlane/plugin/rename_android_package/actions/rename_android_package_action.rb
+++ b/lib/fastlane/plugin/rename_android_package/actions/rename_android_package_action.rb
@@ -19,11 +19,17 @@ module Fastlane
         java_sources.each do |file|
           FileUtils.mv file, new_folder_path
         end
-
+        
+     
+        sed = "sed -i "  #linux sed  https://stackoverflow.com/questions/43171648/sed-gives-sed-cant-read-no-such-file-or-directory
+        if FastlaneCore::Helper.mac?
+          sed = "sed -i '' " # mac sed 
+        do
+    
         Bundler.with_clean_env do
-          sh "find #{path}/app/src -name '*.java' -type f -exec sed -i '' 's/#{package_name}/#{new_package_name}/' {} \\;"
-          sh "find #{path}/app/src -name 'AndroidManifest.xml' -type f -exec sed -i '' 's/#{package_name}/#{new_package_name}/' {} \\;"
-          sh "find #{path}/app -name 'build.gradle' -type f -exec sed -i '' 's/#{package_name}/#{new_package_name}/' {} \\;"
+          sh "find #{path}/app/src -name '*.java' -type f -exec #{sed} 's/#{package_name}/#{new_package_name}/' {} \\;"
+          sh "find #{path}/app/src -name 'AndroidManifest.xml' -type f -exec #{sed} 's/#{package_name}/#{new_package_name}/' {} \\;"
+          sh "find #{path}/app -name 'build.gradle' -type f -exec #{sed} 's/#{package_name}/#{new_package_name}/' {} \\;"
         end
       end
 

--- a/lib/fastlane/plugin/rename_android_package/actions/rename_android_package_action.rb
+++ b/lib/fastlane/plugin/rename_android_package/actions/rename_android_package_action.rb
@@ -24,7 +24,7 @@ module Fastlane
         sed = "sed -i "  #linux sed  https://stackoverflow.com/questions/43171648/sed-gives-sed-cant-read-no-such-file-or-directory
         if FastlaneCore::Helper.mac?
           sed = "sed -i '' " # mac sed 
-        do
+        end
     
         Bundler.with_clean_env do
           sh "find #{path}/app/src -name '*.java' -type f -exec #{sed} 's/#{package_name}/#{new_package_name}/' {} \\;"

--- a/lib/fastlane/plugin/rename_android_package/version.rb
+++ b/lib/fastlane/plugin/rename_android_package/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module RenameAndroidPackage
-    VERSION = "0.1.1"
+    VERSION = "0.1.2"
   end
 end

--- a/lib/fastlane/plugin/rename_android_package/version.rb
+++ b/lib/fastlane/plugin/rename_android_package/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module RenameAndroidPackage
-    VERSION = "0.1.0"
+    VERSION = "0.1.1"
   end
 end


### PR DESCRIPTION
feature: making 'sed' command os depended

The `sed` command differs on linux and macOS platforms, see https://stackoverflow.com/a/57766728

This change detect the runner OS and uses the appropriate `sed` syntax 
